### PR TITLE
fix SerializableDataClass.deserialize

### DIFF
--- a/src/carica/models/dataclasses.py
+++ b/src/carica/models/dataclasses.py
@@ -4,11 +4,13 @@ from carica.typeChecking import objectIsShallowSerializable, objectIsDeepSeriali
 from typing import Any, Dict, cast
 
 
-@dataclass
+@dataclass(init=True, repr=True)
 class SerializableDataClass(ISerializable):
     """An dataclass with added serialize/deserialize methods.
     Values stored in the fields of the dataclass are not type checked, but must be primatives/serializable for the serialize
     method to return valid results.
+
+    Subclasses of SerializableDataClass *must* be decorated with `@dataclasses.dataclass` to function properly.
     """
 
 
@@ -77,5 +79,4 @@ class SerializableDataClass(ISerializable):
             
             data = cast(Dict[str, Any], data)
 
-        return cls(**data **kwargs) # type: ignore
-    
+        return cls(**data, **kwargs) # type: ignore


### PR DESCRIPTION
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Trimatix/2551cac90336c1d1073d8615407cc72d/raw/Carica__pull_24.json)

**Notes for reviewer:**

* syntax error in `SerializableDataClass.deserialize` corrected
* Reminder note added to class docstring that all subclasses must be decorated with `@dataclass`