### PR TITLE
minimize the size of serialized SerializableTimeDelta

### DIFF
--- a/src/carica/models/timedelta.py
+++ b/src/carica/models/timedelta.py
@@ -2,6 +2,8 @@ from typing import Dict
 from carica.interface.Serializable import ISerializable, PrimativeType
 from datetime import timedelta
 
+_KEYS = {"weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
+
 class SerializableTimedelta(ISerializable, timedelta):
     """A serializable version of `datetime.timedelta`. For `datetime.datetime`, no extra handling is needed,
     as datetime is considered a primitive type by TOML.
@@ -34,6 +36,10 @@ class SerializableTimedelta(ISerializable, timedelta):
         
         data["milliseconds"] = 0 if self.microseconds < 1000 else self.microseconds // 1000
         data["microseconds"] = self.microseconds - data["milliseconds"] * 1000
+
+        for k in _KEYS:
+            if data[k] == 0:
+                del data[k]
             
         return data
 


### PR DESCRIPTION
<!-- Change the ## to your pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Trimatix/2551cac90336c1d1073d8615407cc72d/raw/Carica__pull_##.json)

**Notes for reviewer:**

* filter out zero-valued fields in serialized SerializableTimeDeltas
* Whether or not this feature is actually desirable is still being decided
    * It's nice to know what fields you can use in the config file
    * Could parameterize this in deserializerkwargs