### PR TITLE
accept subclasses on deserialize

### DIFF
--- a/src/carica/carica.py
+++ b/src/carica/carica.py
@@ -472,7 +472,7 @@ def loadCfg(cfgModule: ModuleType, cfgFile: str, badTypeHandling: BadTypeHandlin
                 newValue = type(default).deserialize(newValue, c_badTypeHandling=badTypeHandling, c_variableTrace=[varName])
 
             # Handle variables of different types to that which is defined in the python module
-            if type(newValue) != type(default):
+            if not isinstance(newValue, type(default)):
 
                 # Handle type rejections
                 if badTypeHandling.behaviour == BadTypeBehaviour.REJECT:


### PR DESCRIPTION
The  main use case being `tomlkit.items.DateTime`, which tomlkit deserializes from serialized `datetime`.

<!-- Change the ## to your pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Trimatix/2551cac90336c1d1073d8615407cc72d/raw/Carica__pull_65.json)
