### PR TITLE
Make ISerializable generic

### DIFF
--- a/src/carica/interface/Serializable.py
+++ b/src/carica/interface/Serializable.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Generic, Iterable, Mapping, Type, TypeVar, Union, Protocol, runtime_checkable
 from datetime import datetime
 
@@ -41,7 +41,7 @@ class SerializableType(Protocol):
 TSelf = TypeVar("TSelf")
 
 class ISerializable(Generic[TSelf]):
-    """An object which can be represented entirely by a dictionary of primitives, created with the toDict method.
+    """An object w`hich can be represented entirely by a dictionary of primitives, created with the toDict method.
     This object can then be recreated perfectly using the fromDict method.
     """
     
@@ -71,3 +71,5 @@ class ISerializable(Generic[TSelf]):
 serializableTypes = primativeTypes.copy()
 serializableTypes.add(SerializableType)
 serializableTypesTuple = tuple(serializableTypes)
+
+

--- a/src/carica/interface/Serializable.py
+++ b/src/carica/interface/Serializable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Iterable, Mapping, Union, Protocol, runtime_checkable
+from typing import Generic, Iterable, Mapping, Type, TypeVar, Union, Protocol, runtime_checkable
 from datetime import datetime
 
 # All types acceptable as toml data. Tomlkit handles serializing of datetime objects automatically.
@@ -10,7 +10,6 @@ PrimativeType = Union[int, float, str, bool, datetime, Iterable["PrimativeType"]
 primativeTypes = {int, float, str, bool, Iterable, Mapping, datetime, type(None)}
 # PrimativeTypes as a shallow tuple
 primativeTypesTuple = tuple(primativeTypes)
-
 
 @runtime_checkable
 class SerializableType(Protocol):
@@ -39,14 +38,15 @@ class SerializableType(Protocol):
         """
         ...
 
+TSelf = TypeVar("TSelf")
 
-class ISerializable(ABC):
+class ISerializable(Generic[TSelf]):
     """An object which can be represented entirely by a dictionary of primitives, created with the toDict method.
     This object can then be recreated perfectly using the fromDict method.
     """
     
     @abstractmethod
-    def serialize(self, **kwargs) -> PrimativeType:
+    def serialize(self: TSelf, **kwargs) -> PrimativeType:
         """Serialize this object into primative types (likely a dictionary, e.g JSON), to be recreated completely.
 
         :return: A primative (likely a dictionary) containing all information needed to recreate this object
@@ -57,7 +57,7 @@ class ISerializable(ABC):
 
     @classmethod
     @abstractmethod
-    def deserialize(cls, data: PrimativeType, **kwargs) -> ISerializable:
+    def deserialize(cls: Type[TSelf], data: PrimativeType, **kwargs) -> TSelf:
         """Recreate a serialized ISerializable object
 
         :param PrimativeType data: A primative (likely a dictionary) containing all information needed to recreate the serialized object

--- a/src/carica/interface/Serializable.py
+++ b/src/carica/interface/Serializable.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Generic, Iterable, Mapping, Type, TypeVar, Union, Protocol, runtime_checkable
 from datetime import datetime
 
 # All types acceptable as toml data. Tomlkit handles serializing of datetime objects automatically.
 # Iterable includes set, list and tuple. It also includes dict and str!
-PrimativeType = Union[int, float, str, bool, datetime, Iterable["PrimativeType"], Mapping[str, "PrimativeType"]]   
+PrimativeType = Union[int, float, str, bool, datetime, Iterable["PrimativeType"], Mapping[str, "PrimativeType"]]
 # PrimativeType as a shallow set
 primativeTypes = {int, float, str, bool, Iterable, Mapping, datetime, type(None)}
 # PrimativeTypes as a shallow tuple
@@ -40,13 +40,13 @@ class SerializableType(Protocol):
 
 TSelf = TypeVar("TSelf")
 
-class ISerializable(Generic[TSelf]):
-    """An object w`hich can be represented entirely by a dictionary of primitives, created with the toDict method.
+class ISerializable(ABC):
+    """An object which can be represented entirely by a dictionary of primitives, created with the toDict method.
     This object can then be recreated perfectly using the fromDict method.
     """
     
     @abstractmethod
-    def serialize(self: TSelf, **kwargs) -> PrimativeType:
+    def serialize(self, **kwargs) -> PrimativeType:
         """Serialize this object into primative types (likely a dictionary, e.g JSON), to be recreated completely.
 
         :return: A primative (likely a dictionary) containing all information needed to recreate this object
@@ -72,4 +72,13 @@ serializableTypes = primativeTypes.copy()
 serializableTypes.add(SerializableType)
 serializableTypesTuple = tuple(serializableTypes)
 
+TClass = TypeVar("TClass")
+TSerialized = TypeVar("TSerialized", bound=PrimativeType)
 
+class SerializesToType(SerializableType, Generic[TSerialized]):
+    def serialize(self, **kwargs) -> TSerialized: ...
+
+    @classmethod
+    def deserialize(cls: Type[TClass], data: TSerialized, **kwargs) -> TClass: ...
+
+SerializesToDict = SerializesToType[Mapping[str, PrimativeType]]

--- a/src/carica/interface/__init__.py
+++ b/src/carica/interface/__init__.py
@@ -1,3 +1,3 @@
 from .Serializable import ISerializable, SerializableType, \
                             PrimativeType, primativeTypes, primativeTypesTuple, serializableTypes, \
-                            serializableTypesTuple, primativeTypesTuple
+                            serializableTypesTuple, primativeTypesTuple, SerializesToDict, SerializesToType

--- a/src/carica/models/dataclasses.py
+++ b/src/carica/models/dataclasses.py
@@ -1,11 +1,11 @@
 from dataclasses import Field, dataclass, _MISSING_TYPE, fields
-from carica.interface import SerializableType, ISerializable, PrimativeType, primativeTypesTuple
+from carica.interface import SerializableType, ISerializable, PrimativeType, primativeTypesTuple, SerializesToDict
 from carica.typeChecking import objectIsShallowSerializable, objectIsDeepSerializable, _DeserializedTypeOverrideProxy
 from carica.carica import BadTypeHandling, BadTypeBehaviour, ErrorHandling, VariableTrace, log
 from carica import exceptions
 import typing
 import traceback
-from typing import Any, Dict, List, Set, Tuple, Union, cast, TypeVar
+from typing import Any, Dict, List, Mapping, Set, Tuple, Union, cast, TypeVar
 # ignoring a warning here because private type _BaseGenericAlias can't be imported right now.
 # it is a necessary import to unify over user-defined and special generics.
 from typing import _BaseGenericAlias # type: ignore
@@ -250,7 +250,7 @@ def _deserializeField(fieldName: str, fieldType: Union[type, _BaseGenericAlias, 
 
 
 @dataclass(init=True, repr=True, eq=True)
-class SerializableDataClass(ISerializable):
+class SerializableDataClass(SerializesToDict):
     """An dataclass with added serialize/deserialize methods.
     Values stored in the fields of the dataclass are not type checked, but must be primatives/serializable for the serialize
     method to return valid results.
@@ -375,7 +375,7 @@ class SerializableDataClass(ISerializable):
 
 
     @classmethod
-    def deserialize(cls, data, deserializeValues: bool = True, c_variableTrace: VariableTrace = [], **kwargs):
+    def deserialize(cls, data: Mapping[str, PrimativeType], deserializeValues: bool = True, c_variableTrace: VariableTrace = [], **kwargs):
         """Recreate a serialized SerializableDataClass object. If `deserializeValues` is `True`,
         values fields which are serializable types will be automatically deserialized.
 

--- a/src/carica/models/timedelta.py
+++ b/src/carica/models/timedelta.py
@@ -1,6 +1,8 @@
-from typing import Dict
+from typing import Dict, TypeVar, Type
 from carica.interface.Serializable import ISerializable, PrimativeType
 from datetime import timedelta
+
+TSelf = TypeVar("TSelf", bound="SerializableTimedelta")
 
 class SerializableTimedelta(ISerializable, timedelta):
     """A serializable version of `datetime.timedelta`. For `datetime.datetime`, no extra handling is needed,
@@ -39,7 +41,7 @@ class SerializableTimedelta(ISerializable, timedelta):
 
 
     @classmethod
-    def deserialize(cls, data: PrimativeType, **kwargs) -> ISerializable:
+    def deserialize(cls: Type[TSelf], data: PrimativeType, **kwargs) -> TSelf:
         if not isinstance(data, dict):
             raise TypeError(f"Invalid serialized {cls.__name__}: {data}")
         return cls(**data)


### PR DESCRIPTION
<!-- Change the ## to your pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Trimatix/2551cac90336c1d1073d8615407cc72d/raw/Carica__pull_71.json)

**Notes for reviewer:**

* Type `ISerializable.deserialize` to return an instance of the subclass instead of `ISerializable` itself
* Do the same for all exposed models
* Add `SerializesToType` generic, allowing type hints that serialize to a type parameter
* Add `SerializesToDict` alias, shorthand for `SerializesToType[Dict]` (kind of)