### PR TITLE
remove old serializer method names from docs

### DIFF
--- a/src/carica/interface/Serializable.py
+++ b/src/carica/interface/Serializable.py
@@ -41,8 +41,8 @@ class SerializableType(Protocol):
 TSelf = TypeVar("TSelf")
 
 class ISerializable(ABC):
-    """An object which can be represented entirely by a dictionary of primitives, created with the toDict method.
-    This object can then be recreated perfectly using the fromDict method.
+    """An object which can be represented entirely by a dictionary of primitives, created with the serialize method.
+    This object can then be recreated perfectly using the deserialize method.
     """
     
     @abstractmethod


### PR DESCRIPTION
<!-- Change the ## to your pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Trimatix/2551cac90336c1d1073d8615407cc72d/raw/Carica__pull_73.json)

**Notes for reviewer:**

* Replace `toDict` with `serialize` and `fromDict` with `deserialize`